### PR TITLE
fix: correct setSelectionRange error on number input

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -378,17 +378,23 @@
 	 */
 	FastClick.prototype.focus = function(targetElement) {
 		var length;
+		var useSelectionRange = deviceIsIOS;
 
-		// Issue #160: on iOS 7, some input elements (e.g. date datetime month) throw a vague TypeError on setSelectionRange. These elements don't have an integer value for the selectionStart and selectionEnd properties, but unfortunately that can't be used for detection because accessing the properties also throws a TypeError. Just check the type instead. Filed as Apple bug #15122724.
-		if (deviceIsIOS && targetElement.setSelectionRange && targetElement.type.indexOf('date') !== 0 && targetElement.type !== 'time' && targetElement.type !== 'month' && targetElement.type !== 'email') {
-			/**
-			 * bugfix: keybaord not shown up instantly in ios 11.3 
-			 */
-			deviceAboveIOS11_3 && targetElement.focus();
-			
-			length = targetElement.value.length;
-			targetElement.setSelectionRange(length, length);
-		} else {
+		if (useSelectionRange) {
+			try {
+				/**
+				 * bugfix: keybaord not shown up instantly in ios 11.3
+				 */
+				deviceAboveIOS11_3 && targetElement.focus();
+
+				length = targetElement.value.length;
+				targetElement.setSelectionRange(length, length);
+			} catch(err) {
+				useSelectionRange = false
+			}
+		}
+
+		if (!useSelectionRange) {
 			targetElement.focus();
 		}
 	};


### PR DESCRIPTION
bugfix: setSelectionRange error on number input
"Failed to execute 'setSelectionRange' on 'HTMLInputElement': The input element's type ('number') does not support "