### PR TITLE
Bugfix/BB10 null pointer exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,6 @@
 
 ## 2018-09-04
 bugfix unknown error: Cannot call method 'toLowerCase' of undefined
+
+## 2020-05-13
+bugfix: Android BlackBerry 10 device null pointer exception

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -837,7 +837,7 @@
 
 			// BlackBerry 10.3+ does not require Fastclick library.
 			// https://github.com/ftlabs/fastclick/issues/251
-			if (blackberryVersion[1] >= 10 && blackberryVersion[2] >= 3) {
+			if (!!blackberryVersion && blackberryVersion[1] >= 10 && blackberryVersion[2] >= 3) {
 				metaViewport = document.querySelector('meta[name=viewport]');
 
 				if (metaViewport) {

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -837,7 +837,7 @@
 
 			// BlackBerry 10.3+ does not require Fastclick library.
 			// https://github.com/ftlabs/fastclick/issues/251
-			if (!!blackberryVersion && blackberryVersion[1] >= 10 && blackberryVersion[2] >= 3) {
+			if (blackberryVersion && blackberryVersion[1] >= 10 && blackberryVersion[2] >= 3) {
 				metaViewport = document.querySelector('meta[name=viewport]');
 
 				if (metaViewport) {

--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -264,7 +264,7 @@
 	 *
 	 * @type boolean
 	 */
-	var deviceIsBlackBerry10 = navigator.userAgent.indexOf('BB10') > 0;
+	var deviceIsBlackBerry10 = !deviceIsAndroid && navigator.userAgent.indexOf('BB10') > 0;
 
 	/**
 	 * Determine whether a given element requires a native click.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-fastclick",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Polyfill to remove click delays on browsers with touch UIs.",
   "maintainers": [
     {


### PR DESCRIPTION
Some Blackberry device with full Android OS doesn't have the 'Version' keyword in their user-agent, but still has the 'BB10' keyword (which make them classified as BB10 device). It'll cause an NPE error when that particular device is trying to run this library.